### PR TITLE
Feature/update retrieved entity

### DIFF
--- a/src/main/java/es/in2/blockchain/connector/core/service/HashLinkService.java
+++ b/src/main/java/es/in2/blockchain/connector/core/service/HashLinkService.java
@@ -3,5 +3,5 @@ package es.in2.blockchain.connector.core.service;
 public interface HashLinkService {
     String createHashLink(String id, String entityData);
     String resolveHashlink(String dataLocation);
-    boolean compareHashLinks(String dataLocation, String originOffChaiEntity);
+    boolean compareHashLinksFromEntities(String dataLocation, String originOffChaiEntity);
 }

--- a/src/main/java/es/in2/blockchain/connector/core/service/HashLinkService.java
+++ b/src/main/java/es/in2/blockchain/connector/core/service/HashLinkService.java
@@ -3,4 +3,5 @@ package es.in2.blockchain.connector.core.service;
 public interface HashLinkService {
     String createHashLink(String id, String entityData);
     String resolveHashlink(String dataLocation);
+    boolean compareHashLinks(String dataLocation, String originOffChaiEntity);
 }

--- a/src/main/java/es/in2/blockchain/connector/core/service/impl/HashLinkServiceImpl.java
+++ b/src/main/java/es/in2/blockchain/connector/core/service/impl/HashLinkServiceImpl.java
@@ -42,6 +42,15 @@ public class HashLinkServiceImpl implements HashLinkService {
         return retrievedEntity;
     }
 
+    @Override
+    public boolean compareHashLinks(String dataLocation, String originOffChaiEntity) {
+        String originEntityHash = extractHashLink(dataLocation);
+        log.debug(" > Origin entity hash: " + originEntityHash);
+        String retrievedEntityHash = createHashFromEntity(originOffChaiEntity);
+        log.debug(" > Retrieved entity hash: " + retrievedEntityHash);
+        return retrievedEntityHash.equals(originEntityHash);
+    }
+
     private String executeHashlinkRequest(String dataLocation) {
         String offChainEntityOriginUrl = extractOffChainEntityOriginUrl(dataLocation);
         return applicationUtils.getRequest(offChainEntityOriginUrl);

--- a/src/main/java/es/in2/blockchain/connector/core/service/impl/HashLinkServiceImpl.java
+++ b/src/main/java/es/in2/blockchain/connector/core/service/impl/HashLinkServiceImpl.java
@@ -43,10 +43,10 @@ public class HashLinkServiceImpl implements HashLinkService {
     }
 
     @Override
-    public boolean compareHashLinks(String dataLocation, String originOffChaiEntity) {
-        String originEntityHash = extractHashLink(dataLocation);
+    public boolean compareHashLinksFromEntities(String retrievedEntity, String originOffChainEntity) {
+        String originEntityHash = createHashFromEntity(retrievedEntity);
         log.debug(" > Origin entity hash: " + originEntityHash);
-        String retrievedEntityHash = createHashFromEntity(originOffChaiEntity);
+        String retrievedEntityHash = createHashFromEntity(originOffChainEntity);
         log.debug(" > Retrieved entity hash: " + retrievedEntityHash);
         return retrievedEntityHash.equals(originEntityHash);
     }

--- a/src/main/java/es/in2/blockchain/connector/core/service/impl/OffChainEntityServiceImpl.java
+++ b/src/main/java/es/in2/blockchain/connector/core/service/impl/OffChainEntityServiceImpl.java
@@ -64,10 +64,9 @@ public class OffChainEntityServiceImpl implements OffChainEntityService {
 
     private boolean entityExists(String retrievedEntity) {
         String entityId = applicationUtils.jsonExtractId(retrievedEntity);
-        log.debug("> id: " +entityId);
+        log.debug("> Exctracted Entity ID: " +entityId);
         String orionLdEntitiesUrl = orionLdProperties.getOrionLdDomain() + orionLdProperties.getOrionLdPathEntities() + "/"
                 + entityId;
-        log.debug("> orionURL: " +orionLdEntitiesUrl);
         String statusCode = applicationUtils.getRequestCode(orionLdEntitiesUrl);
 
         return statusCode.equals("200");

--- a/src/main/java/es/in2/blockchain/connector/core/service/impl/OffChainEntityServiceImpl.java
+++ b/src/main/java/es/in2/blockchain/connector/core/service/impl/OffChainEntityServiceImpl.java
@@ -28,22 +28,19 @@ public class OffChainEntityServiceImpl implements OffChainEntityService {
         String retrievedEntity = hashLinkService.resolveHashlink(dataLocation);
 
         if (entityExists(retrievedEntity)) {
+            log.debug("> Entity exists");
             String entityId = applicationUtils.jsonExtractId(retrievedEntity);
             String orionLdEntitiesUrl = buildOrionLdEntityUrl(entityId);
             log.debug("> Orion-LD Existing Entity URL: " + orionLdEntitiesUrl);
 
             String existingEntity = applicationUtils.getRequest(orionLdEntitiesUrl);
+            log.debug(retrievedEntity);
 
-            if (!areEntitiesEqual(retrievedEntity, existingEntity)) {
+            if (!areEntitiesEqual(dataLocation, existingEntity)) {
                 log.debug("> Entities not equal");
-                //TODO COMPROBAR DIFERENCIAS JSON
-                
-                //TODO CREAR JSON PARA HACER PATCH REQUEST
-
-
                 // Patch Request
-                applicationUtils.patchRequest(orionLdEntitiesUrl, retrievedEntity);
-                log.info("  > Entity updated in Orion-LD");
+                applicationUtils.patchRequest(orionLdEntitiesUrl + "/attrs", retrievedEntity);
+                log.info("  > Entity updated in off-chain");
             } else {
                 log.info("> Same entities. No changes.");
             }

--- a/src/main/java/es/in2/blockchain/connector/core/service/impl/OffChainEntityServiceImpl.java
+++ b/src/main/java/es/in2/blockchain/connector/core/service/impl/OffChainEntityServiceImpl.java
@@ -21,21 +21,63 @@ public class OffChainEntityServiceImpl implements OffChainEntityService {
     @Override
     public void retrieveAndPublishEntityToOffChain(BlockchainNodeNotificationDTO blockchainNodeNotificationDTO) {
         log.info(">>> Retrieving and publishing entity to off-chain...");
-        // retrieve entity from origin off-chain using dataLocation
+
         String dataLocation = blockchainNodeNotificationDTO.getDataLocation();
         log.debug(" > Data Location: {}", dataLocation);
-        // verify entity with hashlink
+
         String retrievedEntity = hashLinkService.resolveHashlink(dataLocation);
-        // publish retrieved entity to our off-chain storage
-        publishEntityToDestinationOffChain(retrievedEntity);
-        log.info("  > Entity published to off-chain");
+
+        if (entityExists(retrievedEntity)) {
+            String entityId = applicationUtils.jsonExtractId(retrievedEntity);
+            String orionLdEntitiesUrl = buildOrionLdEntityUrl(entityId);
+            log.debug("> Orion-LD Existing Entity URL: " + orionLdEntitiesUrl);
+
+            String existingEntity = applicationUtils.getRequest(orionLdEntitiesUrl);
+
+            if (!areEntitiesEqual(retrievedEntity, existingEntity)) {
+                log.debug("> Entities not equal");
+                //TODO COMPROBAR DIFERENCIAS JSON
+                
+                //TODO CREAR JSON PARA HACER PATCH REQUEST
+
+
+                // Patch Request
+                applicationUtils.patchRequest(orionLdEntitiesUrl, retrievedEntity);
+                log.info("  > Entity updated in Orion-LD");
+            } else {
+                log.info("> Same entities. No changes.");
+            }
+        } else {
+            publishEntityToDestinationOffChain(retrievedEntity);
+            log.info("  > Entity published to off-chain");
+        }
     }
+
+    private String buildOrionLdEntityUrl(String entityId) {
+        return orionLdProperties.getOrionLdDomain() + orionLdProperties.getOrionLdPathEntities() + "/" + entityId;
+    }
+
 
     private void publishEntityToDestinationOffChain(String retrievedEntity) {
         String orionLdEntitiesUrl = orionLdProperties.getApiDomain() + orionLdProperties.getApiPathEntities();
         log.debug(" > Publishing entity to: {}", orionLdEntitiesUrl);
         log.debug(" > Entity to publish: {}", retrievedEntity);
         applicationUtils.postRequest(orionLdEntitiesUrl, retrievedEntity);
+    }
+
+    private boolean entityExists(String retrievedEntity) {
+        String entityId = applicationUtils.jsonExtractId(retrievedEntity);
+        log.debug("> id: " +entityId);
+        String orionLdEntitiesUrl = orionLdProperties.getOrionLdDomain() + orionLdProperties.getOrionLdPathEntities() + "/"
+                + entityId;
+        log.debug("> orionURL: " +orionLdEntitiesUrl);
+        String statusCode = applicationUtils.getRequestCode(orionLdEntitiesUrl);
+
+        return statusCode.equals("200");
+    }
+
+    private boolean areEntitiesEqual(String datalocation, String existingEntity) {
+        return hashLinkService.compareHashLinks(datalocation, existingEntity);
     }
 
 }

--- a/src/main/java/es/in2/blockchain/connector/core/utils/ApplicationUtils.java
+++ b/src/main/java/es/in2/blockchain/connector/core/utils/ApplicationUtils.java
@@ -126,21 +126,4 @@ public class ApplicationUtils {
         return result.toString();
     }
 
-    public String jsonExtractId(String jsonString) {
-        try {
-            ObjectMapper objectMapper = new ObjectMapper();
-            JsonNode jsonNode = objectMapper.readTree(jsonString);
-            JsonNode idNode = jsonNode.get("id");
-
-            if (idNode != null) {
-                return idNode.asText();
-            } else {
-                return null;
-            }
-        } catch (Exception e) {
-            e.printStackTrace();
-            return null;
-        }
-    }
-
 }

--- a/src/main/resources/integration-config.yml
+++ b/src/main/resources/integration-config.yml
@@ -11,7 +11,7 @@ orion-ld-if:
     domain: http://sp-blockchain-connector-orionld-intf:8080
     path:
       subscription: /api/v1/subscriptions
-      entities: /api/v1/entities
+      entities: /api/v1/publish
   subscription:
     type: "Subscription"
     notification-endpoint-uri: http://sp-blockchain-connector-core:8080/notifications/orion-ld
@@ -35,3 +35,10 @@ blockchain-node-if:
   node:
     rpcAddress: https://red-t.alastria.io/v0/9461d9f4292b41230527d57ee90652a6
     userEthereumAddress: "0xb794f5ea0ba39494ce839613fffba74279579268"
+
+
+
+
+
+
+

--- a/src/test/java/es/in2/blockchain/connector/core/service/HashLinkServiceImplTest.java
+++ b/src/test/java/es/in2/blockchain/connector/core/service/HashLinkServiceImplTest.java
@@ -87,7 +87,7 @@ class HashLinkServiceImplTest {
         // Call the compareHashlinks method with some input parameters
         String dataLocation = "https://example.com/entity?hl=mockedHash";
         String originOffChaiEntity = "This is the entity data";
-        boolean result = hashLinkService.compareHashLinks(dataLocation, originOffChaiEntity);
+        boolean result = hashLinkService.compareHashLinksFromEntities(dataLocation, originOffChaiEntity);
         // Assert that the expected result is returned
         assertTrue(result);
         // Verify that the createHashFromEntity method was called with the expected parameter
@@ -96,14 +96,13 @@ class HashLinkServiceImplTest {
 
     @Test
      void testCompareHashlinksWithDifferentOnes() throws Exception {
-        // Mock the createHashFromEntity method to return a specific value
-        when(applicationUtils.calculateSHA256Hash(anyString())).thenReturn("different");
         // Call the compareHashlinks method with some input parameters
-        String dataLocation = "https://example.com/entity?hl=mockedHash";
-        String originOffChaiEntity = "This is the entity data";
-        boolean result = hashLinkService.compareHashLinks(dataLocation, originOffChaiEntity);
+        String targetOffChainEntity = "Something";
+        when(applicationUtils.calculateSHA256Hash(targetOffChainEntity)).thenReturn("mockedHash");
+        String originOffChaiEntity = "Another thing";
+        when(applicationUtils.calculateSHA256Hash(originOffChaiEntity)).thenReturn("anothermockedHash");
         // Assert that the expected result is returned
-        assertFalse(result);
+        assertFalse(hashLinkService.compareHashLinksFromEntities(targetOffChainEntity, originOffChaiEntity));
         // Verify that the createHashFromEntity method was called with the expected parameter
         verify(applicationUtils).calculateSHA256Hash(originOffChaiEntity);
     }

--- a/src/test/java/es/in2/blockchain/connector/core/service/HashLinkServiceImplTest.java
+++ b/src/test/java/es/in2/blockchain/connector/core/service/HashLinkServiceImplTest.java
@@ -12,9 +12,8 @@ import org.mockito.MockitoAnnotations;
 
 import java.security.NoSuchAlgorithmException;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 class HashLinkServiceImplTest {
 
@@ -79,5 +78,33 @@ class HashLinkServiceImplTest {
 
         // Assert
         assertThrows(InvalidHashlinkComparisonException.class, () -> hashLinkService.resolveHashlink(dataLocation));
+    }
+
+    @Test
+    void testCompareHashlinks() throws Exception {
+        // Mock the createHashFromEntity method to return a specific value
+        when(applicationUtils.calculateSHA256Hash(anyString())).thenReturn("mockedHash");
+        // Call the compareHashlinks method with some input parameters
+        String dataLocation = "https://example.com/entity?hl=mockedHash";
+        String originOffChaiEntity = "This is the entity data";
+        boolean result = hashLinkService.compareHashLinks(dataLocation, originOffChaiEntity);
+        // Assert that the expected result is returned
+        assertTrue(result);
+        // Verify that the createHashFromEntity method was called with the expected parameter
+        verify(applicationUtils).calculateSHA256Hash(originOffChaiEntity);
+    }
+
+    @Test
+     void testCompareHashlinksWithDifferentOnes() throws Exception {
+        // Mock the createHashFromEntity method to return a specific value
+        when(applicationUtils.calculateSHA256Hash(anyString())).thenReturn("different");
+        // Call the compareHashlinks method with some input parameters
+        String dataLocation = "https://example.com/entity?hl=mockedHash";
+        String originOffChaiEntity = "This is the entity data";
+        boolean result = hashLinkService.compareHashLinks(dataLocation, originOffChaiEntity);
+        // Assert that the expected result is returned
+        assertFalse(result);
+        // Verify that the createHashFromEntity method was called with the expected parameter
+        verify(applicationUtils).calculateSHA256Hash(originOffChaiEntity);
     }
 }

--- a/src/test/java/es/in2/blockchain/connector/core/service/OffChainEntityServiceImplTest.java
+++ b/src/test/java/es/in2/blockchain/connector/core/service/OffChainEntityServiceImplTest.java
@@ -10,7 +10,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 
+import java.util.NoSuchElementException;
+
 import static org.mockito.Mockito.*;
+
 
 class OffChainEntityServiceImplTest {
 
@@ -37,15 +40,41 @@ class OffChainEntityServiceImplTest {
     void testRetrieveAndPublishEntityToOffChain_EntityExists_EntitiesNotEqual() {
       // Arrange
       String dataLocation = "exampleDataLocation";
-      String retrievedEntity = "retrievedEntity"; // Retrieved entity data
-      String entityId = "exampleEntityId";
+      String retrievedEntity = """
+              "{\\n" +
+                  "  \\"@context\\": \\"https://schema.lab.fiware.org/ld/context\\",\\n" +
+                  "  \\"@type\\": \\"Device\\",\\n" +
+                  "  \\"id\\": \\"urn:ngsi-ld:Device:001\\",\\n" +
+                  "  \\"name\\": {\\n" +
+                  "    \\"type\\": \\"Text\\",\\n" +
+                  "    \\"value\\": \\"Sensor de Temperatura\\"\\n" +
+                  "  },\\n" +
+                  "  \\"temperature\\": {\\n" +
+                  "    \\"type\\": \\"Number\\",\\n" +
+                  "    \\"value\\": 25.5,\\n" +
+                  "    \\"metadata\\": {\\n" +
+                  "      \\"unitCode\\": {\\n" +
+                  "        \\"type\\": \\"Text\\",\\n" +
+                  "        \\"value\\": \\"CEL\\"\\n" +
+                  "      }\\n" +
+                  "    }\\n" +
+                  "  },\\n" +
+                  "  \\"location\\": {\\n" +
+                  "    \\"type\\": \\"GeoProperty\\",\\n" +
+                  "    \\"value\\": {\\n" +
+                  "      \\"type\\": \\"Point\\",\\n" +
+                  "      \\"coordinates\\": [-3.7037902, 40.4167754]\\n" +
+                  "    }\\n" +
+                  "  },\\n" +
+                  "  \\"status\\": {\\n" +
+                  "    \\"type\\": \\"Text\\",\\n" +
+                  "    \\"value\\": \\"Operativo\\"\\n" +
+                  "  }\\n" +
+                  "}";"""; // Retrieved entity data
       String orionLdEntitiesUrl = "exampleOrionLdEntitiesUrl";
 
       when(hashLinkService.resolveHashlink(dataLocation)).thenReturn(retrievedEntity);
-      when(applicationUtils.jsonExtractId(retrievedEntity)).thenReturn(entityId);
       when(applicationUtils.getRequest(orionLdEntitiesUrl)).thenReturn("existingEntity");
-      when(applicationUtils.getRequestCode(anyString())).thenReturn("200");
-      when(hashLinkService.compareHashLinks(dataLocation, "existingEntity")).thenReturn(false);
 
       // Act
       offChainEntityService.retrieveAndPublishEntityToOffChain(createNotification(dataLocation));
@@ -58,15 +87,42 @@ class OffChainEntityServiceImplTest {
    void testRetrieveAndPublishEntityToOffChain_EntityExists_EntitiesEqual() {
       // Arrange
       String dataLocation = "exampleDataLocation";
-      String retrievedEntity = "retrievedEntity"; // Retrieved entity data
-      String entityId = "exampleEntityId";
+      String retrievedEntity = """
+              {
+                "@context": "https://schema.lab.fiware.org/ld/context",
+                "@type": "Device",
+                "id": "urn:ngsi-ld:Device:001",
+                "name": {
+                  "type": "Text",
+                  "value": "Sensor de Temperatura"
+                },
+                "temperature": {
+                  "type": "Number",
+                  "value": 25.5,
+                  "metadata": {
+                    "unitCode": {
+                      "type": "Text",
+                      "value": "CEL"
+                    }
+                  }
+                },
+                "location": {
+                  "type": "GeoProperty",
+                  "value": {
+                    "type": "Point",
+                    "coordinates": [-3.7037902, 40.4167754]
+                  }
+                },
+                "status": {
+                  "type": "Text",
+                  "value": "Operativo"
+                }
+              }"""; // Retrieved entity data
       String orionLdEntitiesUrl = "exampleOrionLdEntitiesUrl";
 
-      when(hashLinkService.resolveHashlink(dataLocation)).thenReturn(retrievedEntity);
-      when(applicationUtils.jsonExtractId(retrievedEntity)).thenReturn(entityId);
+      when(hashLinkService.resolveHashlink(any())).thenReturn(retrievedEntity);
       when(applicationUtils.getRequest(orionLdEntitiesUrl)).thenReturn(retrievedEntity);
-      when(applicationUtils.getRequestCode(anyString())).thenReturn("200");
-      when(hashLinkService.compareHashLinks(any(), any())).thenReturn(true);
+      when(hashLinkService.compareHashLinksFromEntities(any(), any())).thenReturn(true);
 
       // Act
       offChainEntityService.retrieveAndPublishEntityToOffChain(createNotification(dataLocation));
@@ -80,13 +136,43 @@ class OffChainEntityServiceImplTest {
    @Test
    void testRetrieveAndPublishEntityToOffChain_EntityDoesNotExist() {
       // Arrange
-      String dataLocation = "exampleDataLocation";
-      String retrievedEntity = "retrievedEntity"; // Retrieved entity data
-      String entityId = "exampleEntityId";
+      String dataLocation = "exampleDataLocation?hl=e021ea41bdde9dc49e266d1d1b9c71a098ff79b86edcc764edc2dc803ca1f927";
+      String retrievedEntity = """
+              {
+                "@context": "https://schema.lab.fiware.org/ld/context",
+                "@type": "Device",
+                "id": "urn:ngsi-ld:Device:001",
+                "name": {
+                  "type": "Text",
+                  "value": "Sensor de Temperatura"
+                },
+                "temperature": {
+                  "type": "Number",
+                  "value": 25.5,
+                  "metadata": {
+                    "unitCode": {
+                      "type": "Text",
+                      "value": "CEL"
+                    }
+                  }
+                },
+                "location": {
+                  "type": "GeoProperty",
+                  "value": {
+                    "type": "Point",
+                    "coordinates": [-3.7037902, 40.4167754]
+                  }
+                },
+                "status": {
+                  "type": "Text",
+                  "value": "Operativo"
+                }
+              }""";
+
 
       when(hashLinkService.resolveHashlink(dataLocation)).thenReturn(retrievedEntity);
-      when(applicationUtils.jsonExtractId(retrievedEntity)).thenReturn(entityId);
-      when(applicationUtils.getRequestCode(any())).thenReturn("404");
+      when(applicationUtils.getRequest(any())).thenThrow(NoSuchElementException.class);
+
 
       // Act
       offChainEntityService.retrieveAndPublishEntityToOffChain(createNotification(dataLocation));

--- a/src/test/java/es/in2/blockchain/connector/core/service/OffChainEntityServiceImplTest.java
+++ b/src/test/java/es/in2/blockchain/connector/core/service/OffChainEntityServiceImplTest.java
@@ -41,7 +41,6 @@ class OffChainEntityServiceImplTest {
       String entityId = "exampleEntityId";
       String orionLdEntitiesUrl = "exampleOrionLdEntitiesUrl";
 
-      // Mock the behavior of dependencies
       when(hashLinkService.resolveHashlink(dataLocation)).thenReturn(retrievedEntity);
       when(applicationUtils.jsonExtractId(retrievedEntity)).thenReturn(entityId);
       when(applicationUtils.getRequest(orionLdEntitiesUrl)).thenReturn("existingEntity");
@@ -63,17 +62,17 @@ class OffChainEntityServiceImplTest {
       String entityId = "exampleEntityId";
       String orionLdEntitiesUrl = "exampleOrionLdEntitiesUrl";
 
-      // Mock the behavior of dependencies
       when(hashLinkService.resolveHashlink(dataLocation)).thenReturn(retrievedEntity);
       when(applicationUtils.jsonExtractId(retrievedEntity)).thenReturn(entityId);
       when(applicationUtils.getRequest(orionLdEntitiesUrl)).thenReturn(retrievedEntity);
       when(applicationUtils.getRequestCode(anyString())).thenReturn("200");
-      when(hashLinkService.compareHashLinks(dataLocation, retrievedEntity)).thenReturn(true);
+      when(hashLinkService.compareHashLinks(any(), any())).thenReturn(true);
 
       // Act
       offChainEntityService.retrieveAndPublishEntityToOffChain(createNotification(dataLocation));
 
       // Assert
+      verify(applicationUtils, never()).patchRequest(any(), any());
       verify(applicationUtils, never()).postRequest(any(), any());
 
    }
@@ -84,9 +83,7 @@ class OffChainEntityServiceImplTest {
       String dataLocation = "exampleDataLocation";
       String retrievedEntity = "retrievedEntity"; // Retrieved entity data
       String entityId = "exampleEntityId";
-      String orionLdEntitiesUrl = "exampleOrionLdEntitiesUrl";
 
-      // Mock the behavior of dependencies
       when(hashLinkService.resolveHashlink(dataLocation)).thenReturn(retrievedEntity);
       when(applicationUtils.jsonExtractId(retrievedEntity)).thenReturn(entityId);
       when(applicationUtils.getRequestCode(any())).thenReturn("404");
@@ -96,7 +93,6 @@ class OffChainEntityServiceImplTest {
 
       // Assert
        verify(applicationUtils, times(1)).postRequest(any(), any());
-      // Add more assertions if needed
    }
 
    // Helper method to create a BlockchainNodeNotificationDTO
@@ -106,5 +102,4 @@ class OffChainEntityServiceImplTest {
               .build();
    }
 
-   // Add more test methods and assertions as needed
 }


### PR DESCRIPTION
Now core verifies if the entity exists in his Orion-LD before doing anything, if it exists, it will update it

ADD:

-> New methods for comparing purposes
-> New method for just getting the status code of a request
-> New hashlink comparison methods to check differences
-> New patch method on utils for update requests
-> New tests in OffChainEntityService and HashLinkService, coverage +80%